### PR TITLE
Log lists of records as hashes.

### DIFF
--- a/lib/aws-app-logger.rb
+++ b/lib/aws-app-logger.rb
@@ -72,10 +72,18 @@ module Aws
           end
 
         # ...and the second thing that you pass becomes a line of JSON data.
-        if (remainder = args).count.eql?(1)
-          remainder = remainder.first
-        end
-        message += Oj.dump(remainder)
+        data_to_log =
+          if (remainder = args).count.eql?(1)
+            remainder.first
+          else
+            # The JSON parsing in the Lambda-to-Cloudwatch logs will not
+            # recognize a list as valid JSON.  It looks for the first hash
+            # that it can find in the log entry.  So, we must pack the list
+            # into a hash.
+            {records: remainder}
+          end
+        message += Oj.dump(data_to_log)
+
         # Unless you suppress it, you'll also see your data pretty-printed.
         if self.pretty
           message += Rainbow.uncolor(

--- a/test/aws/app/logger_test.rb
+++ b/test/aws/app/logger_test.rb
@@ -69,8 +69,8 @@ class Aws::App::LoggerTest < Test::Unit::TestCase
       {id:'10102001', total:'1295', subtotal:'...'}
     assert(
       output.string.include?(@@test_message) &&
-      JSON.parse(output.string.split("\n")[1])[0]['action'].eql?('sale') &&
-      JSON.parse(output.string.split("\n")[1])[1]['id'].eql?('10102001')
+      JSON.parse(output.string.split("\n")[1])['records'][0]['action'].eql?('sale') &&
+      JSON.parse(output.string.split("\n")[1])['records'][1]['id'].eql?('10102001')
     )
   end
 
@@ -80,10 +80,11 @@ class Aws::App::LoggerTest < Test::Unit::TestCase
       {action:'sale'},
       {id:'10102001', total:'1295', subtotal:'...'}
     )
+    puts "OUTPUT: #{output.string}"
     assert(
-      (data = JSON.parse(output.string.split(/^[\S]+\s/)[1])).first['action'].
+      (data = JSON.parse(output.string.split(/^[\S]+\s/)[1]))['records'].first['action'].
         eql?('sale') &&
-      data.last['id'].eql?('10102001')
+      data['records'].last['id'].eql?('10102001')
     )
   end
 


### PR DESCRIPTION
Because the AWS Lambda-to-Cloudwatch JSON parsing for logs does not recognize JSON lists as valid JSON objects, even though they are.  It looks for the first hash in the log entry.